### PR TITLE
feat: truncate commit message

### DIFF
--- a/renovate-config-bigpopakap/package.json
+++ b/renovate-config-bigpopakap/package.json
@@ -17,6 +17,8 @@
       ],
       "automerge": true,
       "semanticCommits": true,
+      "commitBodyTable": true,
+      "commitMessageTopic": "{{depName}}",
       "packageRules": [
         {
           "packagePatterns": [


### PR DESCRIPTION
Truncate the commit message generated by renovate in order to allow merging #39, which was blocked because commitlint has a 72 character limit