### PR TITLE
fix: rename repo references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-shared-ts-configs
+shared-node-tools
 =================
 
 This monorepo has configurations for bigpopakap's Typescript/JS/React/Express projects.

--- a/eslint-config-bigpopakap/CHANGELOG.md
+++ b/eslint-config-bigpopakap/CHANGELOG.md
@@ -1,26 +1,26 @@
-# [eslint-config-bigpopakap-v2.0.2](https://github.com/bigpopakap/shared-ts-configs/compare/v2.0.1-eslint-config-bigpopakap...v2.0.2-eslint-config-bigpopakap) (2019-11-13)
+# [eslint-config-bigpopakap-v2.0.2](https://github.com/bigpopakap/shared-node-tools/compare/v2.0.1-eslint-config-bigpopakap...v2.0.2-eslint-config-bigpopakap) (2019-11-13)
 
 
 ### Bug Fixes
 
-* **react-app:** fix missing dependencies in bigpopakap/react config ([8c2d586](https://github.com/bigpopakap/shared-ts-configs/commit/8c2d5862a668870a12412e0c5b940fce750d788c))
+* **react-app:** fix missing dependencies in bigpopakap/react config ([8c2d586](https://github.com/bigpopakap/shared-node-tools/commit/8c2d5862a668870a12412e0c5b940fce750d788c))
 
-# [eslint-config-bigpopakap-v2.0.1](https://github.com/bigpopakap/shared-ts-configs/compare/v2.0.0-eslint-config-bigpopakap...v2.0.1-eslint-config-bigpopakap) (2019-11-11)
+# [eslint-config-bigpopakap-v2.0.1](https://github.com/bigpopakap/shared-node-tools/compare/v2.0.0-eslint-config-bigpopakap...v2.0.1-eslint-config-bigpopakap) (2019-11-11)
 
 
 ### Bug Fixes
 
-* **deps:** update typescript-eslint monorepo to v2.7.0 ([2b81d9b](https://github.com/bigpopakap/shared-ts-configs/commit/2b81d9b74a57a6bdbe7df6e8a539276471ca05fc))
+* **deps:** update typescript-eslint monorepo to v2.7.0 ([2b81d9b](https://github.com/bigpopakap/shared-node-tools/commit/2b81d9b74a57a6bdbe7df6e8a539276471ca05fc))
 
-# [eslint-config-bigpopakap-v2.0.0](https://github.com/bigpopakap/shared-ts-configs/compare/v1.2.4-eslint-config-bigpopakap...v2.0.0-eslint-config-bigpopakap) (2019-11-11)
+# [eslint-config-bigpopakap-v2.0.0](https://github.com/bigpopakap/shared-node-tools/compare/v1.2.4-eslint-config-bigpopakap...v2.0.0-eslint-config-bigpopakap) (2019-11-11)
 
 
 ### Features
 
-* add async/await rules as errors ([836b14f](https://github.com/bigpopakap/shared-ts-configs/commit/836b14fcd2d4a1021382255002d0c48e46f413f4)), closes [#72](https://github.com/bigpopakap/shared-ts-configs/issues/72)
-* add eslint-plugin-absolute-import ([a89009e](https://github.com/bigpopakap/shared-ts-configs/commit/a89009e4dec182c91079ffb8068f4a0f5cb139c7))
-* add node specification for bigpopakap/node ([93eb786](https://github.com/bigpopakap/shared-ts-configs/commit/93eb78673de214a76ee8330a9378ed7bc11362bf))
-* extend eslint:recommended rules ([2ab0c86](https://github.com/bigpopakap/shared-ts-configs/commit/2ab0c86c2a1fe05b29f328f1c2a1323451d800cd))
+* add async/await rules as errors ([836b14f](https://github.com/bigpopakap/shared-node-tools/commit/836b14fcd2d4a1021382255002d0c48e46f413f4)), closes [#72](https://github.com/bigpopakap/shared-node-tools/issues/72)
+* add eslint-plugin-absolute-import ([a89009e](https://github.com/bigpopakap/shared-node-tools/commit/a89009e4dec182c91079ffb8068f4a0f5cb139c7))
+* add node specification for bigpopakap/node ([93eb786](https://github.com/bigpopakap/shared-node-tools/commit/93eb78673de214a76ee8330a9378ed7bc11362bf))
+* extend eslint:recommended rules ([2ab0c86](https://github.com/bigpopakap/shared-node-tools/commit/2ab0c86c2a1fe05b29f328f1c2a1323451d800cd))
 
 
 ### BREAKING CHANGES
@@ -33,142 +33,142 @@ https://eslint.org/docs/rules/
 absolute-import/no-relative-path and  absolute-import/no-unresolved. See
 https://github.com/mcclowes/eslint-plugin-absolute-import
 
-# [eslint-config-bigpopakap-v1.2.4](https://github.com/bigpopakap/shared-ts-configs/compare/v1.2.3-eslint-config-bigpopakap...v1.2.4-eslint-config-bigpopakap) (2019-11-09)
+# [eslint-config-bigpopakap-v1.2.4](https://github.com/bigpopakap/shared-node-tools/compare/v1.2.3-eslint-config-bigpopakap...v1.2.4-eslint-config-bigpopakap) (2019-11-09)
 
 
 ### Bug Fixes
 
-* **deps:** update prettier to v1.19.1 ([942eb9d](https://github.com/bigpopakap/shared-ts-configs/commit/942eb9d87cb4412a8ae2c35f83c5723fcf54d0d7))
+* **deps:** update prettier to v1.19.1 ([942eb9d](https://github.com/bigpopakap/shared-node-tools/commit/942eb9d87cb4412a8ae2c35f83c5723fcf54d0d7))
 
-# [eslint-config-bigpopakap-v1.2.3](https://github.com/bigpopakap/shared-ts-configs/compare/v1.2.2-eslint-config-bigpopakap...v1.2.3-eslint-config-bigpopakap) (2019-11-09)
-
-
-### Bug Fixes
-
-* **deps:** add eslint-plugin-react ([15f5abb](https://github.com/bigpopakap/shared-ts-configs/commit/15f5abb262c8edb0d0ba3778b2226be7b4c65928))
-
-# [eslint-config-bigpopakap-v1.2.2](https://github.com/bigpopakap/shared-ts-configs/compare/v1.2.1-eslint-config-bigpopakap...v1.2.2-eslint-config-bigpopakap) (2019-11-09)
+# [eslint-config-bigpopakap-v1.2.3](https://github.com/bigpopakap/shared-node-tools/compare/v1.2.2-eslint-config-bigpopakap...v1.2.3-eslint-config-bigpopakap) (2019-11-09)
 
 
 ### Bug Fixes
 
-* **bin-scripts:** revert previous commits ([65261c3](https://github.com/bigpopakap/shared-ts-configs/commit/65261c350e4886a39ba35092ea561ff233e383e5)), closes [#60](https://github.com/bigpopakap/shared-ts-configs/issues/60)
+* **deps:** add eslint-plugin-react ([15f5abb](https://github.com/bigpopakap/shared-node-tools/commit/15f5abb262c8edb0d0ba3778b2226be7b4c65928))
 
-# [eslint-config-bigpopakap-v1.2.1](https://github.com/bigpopakap/shared-ts-configs/compare/v1.2.0-eslint-config-bigpopakap...v1.2.1-eslint-config-bigpopakap) (2019-11-09)
+# [eslint-config-bigpopakap-v1.2.2](https://github.com/bigpopakap/shared-node-tools/compare/v1.2.1-eslint-config-bigpopakap...v1.2.2-eslint-config-bigpopakap) (2019-11-09)
 
 
 ### Bug Fixes
 
-* **deps:** update prettier to v1.19.0 ([422671d](https://github.com/bigpopakap/shared-ts-configs/commit/422671d97a058c150ca01e0aef7034315b69fd4e))
+* **bin-scripts:** revert previous commits ([65261c3](https://github.com/bigpopakap/shared-node-tools/commit/65261c350e4886a39ba35092ea561ff233e383e5)), closes [#60](https://github.com/bigpopakap/shared-node-tools/issues/60)
 
-# [eslint-config-bigpopakap-v1.2.0](https://github.com/bigpopakap/shared-ts-configs/compare/v1.1.8-eslint-config-bigpopakap...v1.2.0-eslint-config-bigpopakap) (2019-11-09)
+# [eslint-config-bigpopakap-v1.2.1](https://github.com/bigpopakap/shared-node-tools/compare/v1.2.0-eslint-config-bigpopakap...v1.2.1-eslint-config-bigpopakap) (2019-11-09)
+
+
+### Bug Fixes
+
+* **deps:** update prettier to v1.19.0 ([422671d](https://github.com/bigpopakap/shared-node-tools/commit/422671d97a058c150ca01e0aef7034315b69fd4e))
+
+# [eslint-config-bigpopakap-v1.2.0](https://github.com/bigpopakap/shared-node-tools/compare/v1.1.8-eslint-config-bigpopakap...v1.2.0-eslint-config-bigpopakap) (2019-11-09)
 
 
 ### Features
 
-* **bin-script:** don't specify file extensions to eslint ([248ae39](https://github.com/bigpopakap/shared-ts-configs/commit/248ae39d718f05e2e3787c7a5fe3cc0bb34f5a68)), closes [#60](https://github.com/bigpopakap/shared-ts-configs/issues/60)
-* **bin-scripts:** run in current dir, add more file exts ([4ea7a77](https://github.com/bigpopakap/shared-ts-configs/commit/4ea7a775d42305def5db43e91adaf7b73f640759)), closes [#60](https://github.com/bigpopakap/shared-ts-configs/issues/60)
+* **bin-script:** don't specify file extensions to eslint ([248ae39](https://github.com/bigpopakap/shared-node-tools/commit/248ae39d718f05e2e3787c7a5fe3cc0bb34f5a68)), closes [#60](https://github.com/bigpopakap/shared-node-tools/issues/60)
+* **bin-scripts:** run in current dir, add more file exts ([4ea7a77](https://github.com/bigpopakap/shared-node-tools/commit/4ea7a775d42305def5db43e91adaf7b73f640759)), closes [#60](https://github.com/bigpopakap/shared-node-tools/issues/60)
 
-# [eslint-config-bigpopakap-v1.1.8](https://github.com/bigpopakap/shared-ts-configs/compare/v1.1.7-eslint-config-bigpopakap...v1.1.8-eslint-config-bigpopakap) (2019-11-05)
-
-
-### Bug Fixes
-
-* **deps:** update typescript to v3.7.2 ([5449189](https://github.com/bigpopakap/shared-ts-configs/commit/5449189be1a7ac25bc404c6e955d8e9c5ba717ed))
-
-# [eslint-config-bigpopakap-v1.1.7](https://github.com/bigpopakap/shared-ts-configs/compare/v1.1.6-eslint-config-bigpopakap...v1.1.7-eslint-config-bigpopakap) (2019-11-04)
+# [eslint-config-bigpopakap-v1.1.8](https://github.com/bigpopakap/shared-node-tools/compare/v1.1.7-eslint-config-bigpopakap...v1.1.8-eslint-config-bigpopakap) (2019-11-05)
 
 
 ### Bug Fixes
 
-* **ci:** fix autopublishing ([25b5002](https://github.com/bigpopakap/shared-ts-configs/commit/25b50021f284aaae64579632a02fe26815d6b49a)), closes [#56](https://github.com/bigpopakap/shared-ts-configs/issues/56)
-* **package.json:** update repo link to point to subdirectories ([5ee5a6a](https://github.com/bigpopakap/shared-ts-configs/commit/5ee5a6acad3345ab6d3f108a45e3f3ba2d844f49))
+* **deps:** update typescript to v3.7.2 ([5449189](https://github.com/bigpopakap/shared-node-tools/commit/5449189be1a7ac25bc404c6e955d8e9c5ba717ed))
 
-# [eslint-config-bigpopakap-v1.1.6](https://github.com/bigpopakap/shared-ts-configs/compare/v1.1.5-eslint-config-bigpopakap...v1.1.6-eslint-config-bigpopakap) (2019-11-04)
-
-
-### Bug Fixes
-
-* **deps:** update typescript-eslint monorepo to v2.6.1 ([22a53f5](https://github.com/bigpopakap/shared-ts-configs/commit/22a53f59001da7e34941e559c4b68a49c3d18df8))
-
-# [eslint-config-bigpopakap-v1.1.5](https://github.com/bigpopakap/shared-ts-configs/compare/v1.1.4-eslint-config-bigpopakap...v1.1.5-eslint-config-bigpopakap) (2019-10-28)
+# [eslint-config-bigpopakap-v1.1.7](https://github.com/bigpopakap/shared-node-tools/compare/v1.1.6-eslint-config-bigpopakap...v1.1.7-eslint-config-bigpopakap) (2019-11-04)
 
 
 ### Bug Fixes
 
-* **deps:** update typescript-eslint monorepo to v2.6.0 ([9e382d6](https://github.com/bigpopakap/shared-ts-configs/commit/9e382d657525cdaedf7f7af751c7da6b43aa6b37))
+* **ci:** fix autopublishing ([25b5002](https://github.com/bigpopakap/shared-node-tools/commit/25b50021f284aaae64579632a02fe26815d6b49a)), closes [#56](https://github.com/bigpopakap/shared-node-tools/issues/56)
+* **package.json:** update repo link to point to subdirectories ([5ee5a6a](https://github.com/bigpopakap/shared-node-tools/commit/5ee5a6acad3345ab6d3f108a45e3f3ba2d844f49))
 
-# [eslint-config-bigpopakap-v1.1.4](https://github.com/bigpopakap/shared-ts-configs/compare/v1.1.3-eslint-config-bigpopakap...v1.1.4-eslint-config-bigpopakap) (2019-10-26)
-
-
-### Bug Fixes
-
-* **deps:** update dependency eslint-config-prettier to v6.5.0 ([2909de4](https://github.com/bigpopakap/shared-ts-configs/commit/2909de488ac72310a3b7a882f0519c0dbbebea11))
-
-# [eslint-config-bigpopakap-v1.1.3](https://github.com/bigpopakap/shared-ts-configs/compare/v1.1.2-eslint-config-bigpopakap...v1.1.3-eslint-config-bigpopakap) (2019-10-25)
+# [eslint-config-bigpopakap-v1.1.6](https://github.com/bigpopakap/shared-node-tools/compare/v1.1.5-eslint-config-bigpopakap...v1.1.6-eslint-config-bigpopakap) (2019-11-04)
 
 
 ### Bug Fixes
 
-* **deps:** update dependency eslint to v6.6.0 ([e01b3fb](https://github.com/bigpopakap/shared-ts-configs/commit/e01b3fbbf7f53f6d03300ed34651b7572aa4ade4))
+* **deps:** update typescript-eslint monorepo to v2.6.1 ([22a53f5](https://github.com/bigpopakap/shared-node-tools/commit/22a53f59001da7e34941e559c4b68a49c3d18df8))
 
-# [eslint-config-bigpopakap-v1.1.2](https://github.com/bigpopakap/shared-ts-configs/compare/v1.1.1-eslint-config-bigpopakap...v1.1.2-eslint-config-bigpopakap) (2019-10-23)
-
-
-### Bug Fixes
-
-* **deps:** update dependency eslint-plugin-json to v2 ([1277834](https://github.com/bigpopakap/shared-ts-configs/commit/12778348775cd7e30738733ee901d79aaeca1f37))
-
-# [eslint-config-bigpopakap-v1.1.1](https://github.com/bigpopakap/shared-ts-configs/compare/v1.1.0-eslint-config-bigpopakap...v1.1.1-eslint-config-bigpopakap) (2019-10-21)
+# [eslint-config-bigpopakap-v1.1.5](https://github.com/bigpopakap/shared-node-tools/compare/v1.1.4-eslint-config-bigpopakap...v1.1.5-eslint-config-bigpopakap) (2019-10-28)
 
 
 ### Bug Fixes
 
-* **deps:** update typescript-eslint monorepo to v2.5.0 ([a3a6961](https://github.com/bigpopakap/shared-ts-configs/commit/a3a69611a9ff93eba2de34d3ff397711a8560592))
+* **deps:** update typescript-eslint monorepo to v2.6.0 ([9e382d6](https://github.com/bigpopakap/shared-node-tools/commit/9e382d657525cdaedf7f7af751c7da6b43aa6b37))
 
-# [eslint-config-bigpopakap-v1.1.0](https://github.com/bigpopakap/shared-ts-configs/compare/v1.0.2-eslint-config-bigpopakap...v1.1.0-eslint-config-bigpopakap) (2019-10-18)
+# [eslint-config-bigpopakap-v1.1.4](https://github.com/bigpopakap/shared-node-tools/compare/v1.1.3-eslint-config-bigpopakap...v1.1.4-eslint-config-bigpopakap) (2019-10-26)
 
 
 ### Bug Fixes
 
-* harcode the --ext option ([3d8b4bb](https://github.com/bigpopakap/shared-ts-configs/commit/3d8b4bb1594363f17fed03b1af515e966eb82d79))
+* **deps:** update dependency eslint-config-prettier to v6.5.0 ([2909de4](https://github.com/bigpopakap/shared-node-tools/commit/2909de488ac72310a3b7a882f0519c0dbbebea11))
+
+# [eslint-config-bigpopakap-v1.1.3](https://github.com/bigpopakap/shared-node-tools/compare/v1.1.2-eslint-config-bigpopakap...v1.1.3-eslint-config-bigpopakap) (2019-10-25)
+
+
+### Bug Fixes
+
+* **deps:** update dependency eslint to v6.6.0 ([e01b3fb](https://github.com/bigpopakap/shared-node-tools/commit/e01b3fbbf7f53f6d03300ed34651b7572aa4ade4))
+
+# [eslint-config-bigpopakap-v1.1.2](https://github.com/bigpopakap/shared-node-tools/compare/v1.1.1-eslint-config-bigpopakap...v1.1.2-eslint-config-bigpopakap) (2019-10-23)
+
+
+### Bug Fixes
+
+* **deps:** update dependency eslint-plugin-json to v2 ([1277834](https://github.com/bigpopakap/shared-node-tools/commit/12778348775cd7e30738733ee901d79aaeca1f37))
+
+# [eslint-config-bigpopakap-v1.1.1](https://github.com/bigpopakap/shared-node-tools/compare/v1.1.0-eslint-config-bigpopakap...v1.1.1-eslint-config-bigpopakap) (2019-10-21)
+
+
+### Bug Fixes
+
+* **deps:** update typescript-eslint monorepo to v2.5.0 ([a3a6961](https://github.com/bigpopakap/shared-node-tools/commit/a3a69611a9ff93eba2de34d3ff397711a8560592))
+
+# [eslint-config-bigpopakap-v1.1.0](https://github.com/bigpopakap/shared-node-tools/compare/v1.0.2-eslint-config-bigpopakap...v1.1.0-eslint-config-bigpopakap) (2019-10-18)
+
+
+### Bug Fixes
+
+* harcode the --ext option ([3d8b4bb](https://github.com/bigpopakap/shared-node-tools/commit/3d8b4bb1594363f17fed03b1af515e966eb82d79))
 
 
 ### Features
 
-* add executable script ([d0abd52](https://github.com/bigpopakap/shared-ts-configs/commit/d0abd526d6181f658f48b6f757128cbab8532333)), closes [#27](https://github.com/bigpopakap/shared-ts-configs/issues/27)
+* add executable script ([d0abd52](https://github.com/bigpopakap/shared-node-tools/commit/d0abd526d6181f658f48b6f757128cbab8532333)), closes [#27](https://github.com/bigpopakap/shared-node-tools/issues/27)
 
-# [eslint-config-bigpopakap-v1.0.2](https://github.com/bigpopakap/shared-ts-configs/compare/v1.0.1-eslint-config-bigpopakap...v1.0.2-eslint-config-bigpopakap) (2019-10-16)
-
-
-### Bug Fixes
-
-* **readme:** update title ([3e27fe8](https://github.com/bigpopakap/shared-ts-configs/commit/3e27fe8b5309b70839954453a314ff0636fb2b9b))
-
-# [eslint-config-bigpopakap-v1.0.1](https://github.com/bigpopakap/shared-ts-configs/compare/v1.0.0-eslint-config-bigpopakap...v1.0.1-eslint-config-bigpopakap) (2019-10-16)
+# [eslint-config-bigpopakap-v1.0.2](https://github.com/bigpopakap/shared-node-tools/compare/v1.0.1-eslint-config-bigpopakap...v1.0.2-eslint-config-bigpopakap) (2019-10-16)
 
 
 ### Bug Fixes
 
-* **package.json:** update description ([71d7b7e](https://github.com/bigpopakap/shared-ts-configs/commit/71d7b7e0acf5be7b49a64c53616d634dc157f056))
-* **readme:** update package description ([b6968c8](https://github.com/bigpopakap/shared-ts-configs/commit/b6968c8f603420720dea88037048677faf169073))
+* **readme:** update title ([3e27fe8](https://github.com/bigpopakap/shared-node-tools/commit/3e27fe8b5309b70839954453a314ff0636fb2b9b))
+
+# [eslint-config-bigpopakap-v1.0.1](https://github.com/bigpopakap/shared-node-tools/compare/v1.0.0-eslint-config-bigpopakap...v1.0.1-eslint-config-bigpopakap) (2019-10-16)
+
+
+### Bug Fixes
+
+* **package.json:** update description ([71d7b7e](https://github.com/bigpopakap/shared-node-tools/commit/71d7b7e0acf5be7b49a64c53616d634dc157f056))
+* **readme:** update package description ([b6968c8](https://github.com/bigpopakap/shared-node-tools/commit/b6968c8f603420720dea88037048677faf169073))
 
 # eslint-config-bigpopakap-v1.0.0 (2019-10-16)
 
 
 ### Bug Fixes
 
-* **autopublish:** try fixing autopublishing of multiple packages ([336a64c](https://github.com/bigpopakap/shared-ts-configs/commit/336a64ce5946173ad9b251c8c5d0423f263f1fba))
-* **autopublish:** try moving releaserc plugins into each package ([4c98eda](https://github.com/bigpopakap/shared-ts-configs/commit/4c98edadfa18f51780d80bab2da772b3ca2c11f5))
-* **autopublish:** trying to fix semantic-release ([a76b056](https://github.com/bigpopakap/shared-ts-configs/commit/a76b056eb31129208e6a193dc4bdcdb9b490eb93))
-* **autopublish:** undo recent changes to add plugins to packages ([2815e7a](https://github.com/bigpopakap/shared-ts-configs/commit/2815e7a82fc17dc4d07c33a709ab9d92d258d2f3))
-* **deps:** add missing required peerDependencies ([4609d6b](https://github.com/bigpopakap/shared-ts-configs/commit/4609d6bc3899c55f0a647939679b9063c7180e9c))
+* **autopublish:** try fixing autopublishing of multiple packages ([336a64c](https://github.com/bigpopakap/shared-node-tools/commit/336a64ce5946173ad9b251c8c5d0423f263f1fba))
+* **autopublish:** try moving releaserc plugins into each package ([4c98eda](https://github.com/bigpopakap/shared-node-tools/commit/4c98edadfa18f51780d80bab2da772b3ca2c11f5))
+* **autopublish:** trying to fix semantic-release ([a76b056](https://github.com/bigpopakap/shared-node-tools/commit/a76b056eb31129208e6a193dc4bdcdb9b490eb93))
+* **autopublish:** undo recent changes to add plugins to packages ([2815e7a](https://github.com/bigpopakap/shared-node-tools/commit/2815e7a82fc17dc4d07c33a709ab9d92d258d2f3))
+* **deps:** add missing required peerDependencies ([4609d6b](https://github.com/bigpopakap/shared-node-tools/commit/4609d6bc3899c55f0a647939679b9063c7180e9c))
 
 
 ### Features
 
-* **rules:** set @typescript-eslint/no-unused-vars to error ([960984c](https://github.com/bigpopakap/shared-ts-configs/commit/960984c00a98f5e02aa196ca00531fe0c23d412a))
-* **version:** publish 1.0.0 version ([c55d8e7](https://github.com/bigpopakap/shared-ts-configs/commit/c55d8e7276a994240eb95deacb06a1702f03f1d1))
+* **rules:** set @typescript-eslint/no-unused-vars to error ([960984c](https://github.com/bigpopakap/shared-node-tools/commit/960984c00a98f5e02aa196ca00531fe0c23d412a))
+* **version:** publish 1.0.0 version ([c55d8e7](https://github.com/bigpopakap/shared-node-tools/commit/c55d8e7276a994240eb95deacb06a1702f03f1d1))
 
 
 ### BREAKING CHANGES
@@ -180,45 +180,45 @@ https://github.com/mcclowes/eslint-plugin-absolute-import
 
 ### Bug Fixes
 
-* **autopublish:** try fixing autopublishing of multiple packages ([336a64c](https://github.com/bigpopakap/shared-ts-configs/commit/336a64ce5946173ad9b251c8c5d0423f263f1fba))
-* **autopublish:** try moving releaserc plugins into each package ([4c98eda](https://github.com/bigpopakap/shared-ts-configs/commit/4c98edadfa18f51780d80bab2da772b3ca2c11f5))
-* **autopublish:** trying to fix semantic-release ([a76b056](https://github.com/bigpopakap/shared-ts-configs/commit/a76b056eb31129208e6a193dc4bdcdb9b490eb93))
-* **autopublish:** undo recent changes to add plugins to packages ([2815e7a](https://github.com/bigpopakap/shared-ts-configs/commit/2815e7a82fc17dc4d07c33a709ab9d92d258d2f3))
-* **deps:** add missing required peerDependencies ([4609d6b](https://github.com/bigpopakap/shared-ts-configs/commit/4609d6bc3899c55f0a647939679b9063c7180e9c))
+* **autopublish:** try fixing autopublishing of multiple packages ([336a64c](https://github.com/bigpopakap/shared-node-tools/commit/336a64ce5946173ad9b251c8c5d0423f263f1fba))
+* **autopublish:** try moving releaserc plugins into each package ([4c98eda](https://github.com/bigpopakap/shared-node-tools/commit/4c98edadfa18f51780d80bab2da772b3ca2c11f5))
+* **autopublish:** trying to fix semantic-release ([a76b056](https://github.com/bigpopakap/shared-node-tools/commit/a76b056eb31129208e6a193dc4bdcdb9b490eb93))
+* **autopublish:** undo recent changes to add plugins to packages ([2815e7a](https://github.com/bigpopakap/shared-node-tools/commit/2815e7a82fc17dc4d07c33a709ab9d92d258d2f3))
+* **deps:** add missing required peerDependencies ([4609d6b](https://github.com/bigpopakap/shared-node-tools/commit/4609d6bc3899c55f0a647939679b9063c7180e9c))
 
 
 ### Features
 
-* **rules:** set @typescript-eslint/no-unused-vars to error ([960984c](https://github.com/bigpopakap/shared-ts-configs/commit/960984c00a98f5e02aa196ca00531fe0c23d412a))
-* **version:** publish 1.0.0 version ([c55d8e7](https://github.com/bigpopakap/shared-ts-configs/commit/c55d8e7276a994240eb95deacb06a1702f03f1d1))
+* **rules:** set @typescript-eslint/no-unused-vars to error ([960984c](https://github.com/bigpopakap/shared-node-tools/commit/960984c00a98f5e02aa196ca00531fe0c23d412a))
+* **version:** publish 1.0.0 version ([c55d8e7](https://github.com/bigpopakap/shared-node-tools/commit/c55d8e7276a994240eb95deacb06a1702f03f1d1))
 
 
 ### BREAKING CHANGES
 
 * **rules:** @typescript-eslint/no-unused-vars is now an error
 
-# [eslint-config-bigpopakap-v1.0.1](https://github.com/bigpopakap/shared-ts-configs/compare/v1.0.0...v1.0.1) (2019-10-16)
+# [eslint-config-bigpopakap-v1.0.1](https://github.com/bigpopakap/shared-node-tools/compare/v1.0.0...v1.0.1) (2019-10-16)
 
 
 ### Bug Fixes
 
-* **deps:** add missing required peerDependencies ([4609d6b](https://github.com/bigpopakap/shared-ts-configs/commit/4609d6bc3899c55f0a647939679b9063c7180e9c))
+* **deps:** add missing required peerDependencies ([4609d6b](https://github.com/bigpopakap/shared-node-tools/commit/4609d6bc3899c55f0a647939679b9063c7180e9c))
 
 # eslint-config-bigpopakap-v1.0.0 (2019-10-16)
 
 
 ### Bug Fixes
 
-* **autopublish:** try fixing autopublishing of multiple packages ([336a64c](https://github.com/bigpopakap/shared-ts-configs/commit/336a64ce5946173ad9b251c8c5d0423f263f1fba))
-* **autopublish:** try moving releaserc plugins into each package ([4c98eda](https://github.com/bigpopakap/shared-ts-configs/commit/4c98edadfa18f51780d80bab2da772b3ca2c11f5))
-* **autopublish:** trying to fix semantic-release ([a76b056](https://github.com/bigpopakap/shared-ts-configs/commit/a76b056eb31129208e6a193dc4bdcdb9b490eb93))
-* **autopublish:** undo recent changes to add plugins to packages ([2815e7a](https://github.com/bigpopakap/shared-ts-configs/commit/2815e7a82fc17dc4d07c33a709ab9d92d258d2f3))
+* **autopublish:** try fixing autopublishing of multiple packages ([336a64c](https://github.com/bigpopakap/shared-node-tools/commit/336a64ce5946173ad9b251c8c5d0423f263f1fba))
+* **autopublish:** try moving releaserc plugins into each package ([4c98eda](https://github.com/bigpopakap/shared-node-tools/commit/4c98edadfa18f51780d80bab2da772b3ca2c11f5))
+* **autopublish:** trying to fix semantic-release ([a76b056](https://github.com/bigpopakap/shared-node-tools/commit/a76b056eb31129208e6a193dc4bdcdb9b490eb93))
+* **autopublish:** undo recent changes to add plugins to packages ([2815e7a](https://github.com/bigpopakap/shared-node-tools/commit/2815e7a82fc17dc4d07c33a709ab9d92d258d2f3))
 
 
 ### Features
 
-* **rules:** set @typescript-eslint/no-unused-vars to error ([960984c](https://github.com/bigpopakap/shared-ts-configs/commit/960984c00a98f5e02aa196ca00531fe0c23d412a))
-* **version:** publish 1.0.0 version ([c55d8e7](https://github.com/bigpopakap/shared-ts-configs/commit/c55d8e7276a994240eb95deacb06a1702f03f1d1))
+* **rules:** set @typescript-eslint/no-unused-vars to error ([960984c](https://github.com/bigpopakap/shared-node-tools/commit/960984c00a98f5e02aa196ca00531fe0c23d412a))
+* **version:** publish 1.0.0 version ([c55d8e7](https://github.com/bigpopakap/shared-node-tools/commit/c55d8e7276a994240eb95deacb06a1702f03f1d1))
 
 
 ### BREAKING CHANGES

--- a/eslint-config-bigpopakap/package.json
+++ b/eslint-config-bigpopakap/package.json
@@ -2,10 +2,10 @@
   "name": "eslint-config-bigpopakap",
   "version": "2.0.2",
   "description": "Shared ESLint configurations for bigpopakap's personal projects",
-  "homepage": "https://github.com/bigpopakap/shared-ts-configs",
+  "homepage": "https://github.com/bigpopakap/shared-node-tools",
   "repository": {
     "type": "git",
-    "url": "https://github.com/bigpopakap/shared-ts-configs"
+    "url": "https://github.com/bigpopakap/shared-node-tools"
   },
   "bin": {
     "eslint-bigpopakap": "./bin/eslint-bigpopakap.js"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@bigpopakap/shared-ts-configs",
+  "name": "@bigpopakap/shared-node-tools",
   "version": "0.1.0",
   "private": true,
   "workspaces": [

--- a/renovate-config-bigpopakap/CHANGELOG.md
+++ b/renovate-config-bigpopakap/CHANGELOG.md
@@ -1,28 +1,28 @@
-# [renovate-config-bigpopakap-v1.1.1](https://github.com/bigpopakap/shared-ts-configs/compare/v1.1.0-renovate-config-bigpopakap...v1.1.1-renovate-config-bigpopakap) (2019-11-04)
+# [renovate-config-bigpopakap-v1.1.1](https://github.com/bigpopakap/shared-node-tools/compare/v1.1.0-renovate-config-bigpopakap...v1.1.1-renovate-config-bigpopakap) (2019-11-04)
 
 
 ### Bug Fixes
 
-* **ci:** fix autopublishing ([25b5002](https://github.com/bigpopakap/shared-ts-configs/commit/25b50021f284aaae64579632a02fe26815d6b49a)), closes [#56](https://github.com/bigpopakap/shared-ts-configs/issues/56)
-* **package.json:** update repo link to point to subdirectories ([5ee5a6a](https://github.com/bigpopakap/shared-ts-configs/commit/5ee5a6acad3345ab6d3f108a45e3f3ba2d844f49))
+* **ci:** fix autopublishing ([25b5002](https://github.com/bigpopakap/shared-node-tools/commit/25b50021f284aaae64579632a02fe26815d6b49a)), closes [#56](https://github.com/bigpopakap/shared-node-tools/issues/56)
+* **package.json:** update repo link to point to subdirectories ([5ee5a6a](https://github.com/bigpopakap/shared-node-tools/commit/5ee5a6acad3345ab6d3f108a45e3f3ba2d844f49))
 
-# [renovate-config-bigpopakap-v1.1.0](https://github.com/bigpopakap/shared-ts-configs/compare/v1.0.0-renovate-config-bigpopakap...v1.1.0-renovate-config-bigpopakap) (2019-10-28)
+# [renovate-config-bigpopakap-v1.1.0](https://github.com/bigpopakap/shared-node-tools/compare/v1.0.0-renovate-config-bigpopakap...v1.1.0-renovate-config-bigpopakap) (2019-10-28)
 
 
 ### Features
 
-* truncate commit message ([925b5bf](https://github.com/bigpopakap/shared-ts-configs/commit/925b5bf5026f6bda4bb7a936fd6468cdc7f825bf)), closes [#39](https://github.com/bigpopakap/shared-ts-configs/issues/39)
+* truncate commit message ([925b5bf](https://github.com/bigpopakap/shared-node-tools/commit/925b5bf5026f6bda4bb7a936fd6468cdc7f825bf)), closes [#39](https://github.com/bigpopakap/shared-node-tools/issues/39)
 
 # renovate-config-bigpopakap-v1.0.0 (2019-10-16)
 
 
 ### Bug Fixes
 
-* set initial version to 0.0.1 ([581afed](https://github.com/bigpopakap/shared-ts-configs/commit/581afed0171d5ac52c15f5b4439eebd5d9afea99))
+* set initial version to 0.0.1 ([581afed](https://github.com/bigpopakap/shared-node-tools/commit/581afed0171d5ac52c15f5b4439eebd5d9afea99))
 
 
 ### Features
 
-* configure package groups ([6fea7f1](https://github.com/bigpopakap/shared-ts-configs/commit/6fea7f17d74217dc7f104ab3d71973e1ccf00ac0))
-* enable renovate for peerDependencies ([f6208e0](https://github.com/bigpopakap/shared-ts-configs/commit/f6208e0d03e691154e7d5c11c9903dd829777c4a)), closes [#12](https://github.com/bigpopakap/shared-ts-configs/issues/12)
-* **renovate-config-bipgopakap:** create new shareable renovate config ([401c97a](https://github.com/bigpopakap/shared-ts-configs/commit/401c97aabaf4062df83663eb071fef5e4b043b53))
+* configure package groups ([6fea7f1](https://github.com/bigpopakap/shared-node-tools/commit/6fea7f17d74217dc7f104ab3d71973e1ccf00ac0))
+* enable renovate for peerDependencies ([f6208e0](https://github.com/bigpopakap/shared-node-tools/commit/f6208e0d03e691154e7d5c11c9903dd829777c4a)), closes [#12](https://github.com/bigpopakap/shared-node-tools/issues/12)
+* **renovate-config-bipgopakap:** create new shareable renovate config ([401c97a](https://github.com/bigpopakap/shared-node-tools/commit/401c97aabaf4062df83663eb071fef5e4b043b53))

--- a/renovate-config-bigpopakap/package.json
+++ b/renovate-config-bigpopakap/package.json
@@ -2,10 +2,10 @@
   "name": "renovate-config-bigpopakap",
   "version": "1.1.1",
   "description": "Shared RenovateBot configurations for bigpopakap's personal projects",
-  "homepage": "https://github.com/bigpopakap/shared-ts-configs",
+  "homepage": "https://github.com/bigpopakap/shared-node-tools",
   "repository": {
     "type": "git",
-    "url": "https://github.com/bigpopakap/shared-ts-configs"
+    "url": "https://github.com/bigpopakap/shared-node-tools"
   },
   "renovate-config": {
     "default": {

--- a/stylelint-config-bigpopakap/CHANGELOG.md
+++ b/stylelint-config-bigpopakap/CHANGELOG.md
@@ -1,70 +1,70 @@
-# [stylelint-config-bigpopakap-v1.2.1](https://github.com/bigpopakap/shared-ts-configs/compare/v1.2.0-stylelint-config-bigpopakap...v1.2.1-stylelint-config-bigpopakap) (2019-11-09)
+# [stylelint-config-bigpopakap-v1.2.1](https://github.com/bigpopakap/shared-node-tools/compare/v1.2.0-stylelint-config-bigpopakap...v1.2.1-stylelint-config-bigpopakap) (2019-11-09)
 
 
 ### Bug Fixes
 
-* **bin-scripts:** revert previous commits ([65261c3](https://github.com/bigpopakap/shared-ts-configs/commit/65261c350e4886a39ba35092ea561ff233e383e5)), closes [#60](https://github.com/bigpopakap/shared-ts-configs/issues/60)
+* **bin-scripts:** revert previous commits ([65261c3](https://github.com/bigpopakap/shared-node-tools/commit/65261c350e4886a39ba35092ea561ff233e383e5)), closes [#60](https://github.com/bigpopakap/shared-node-tools/issues/60)
 
-# [stylelint-config-bigpopakap-v1.2.0](https://github.com/bigpopakap/shared-ts-configs/compare/v1.1.1-stylelint-config-bigpopakap...v1.2.0-stylelint-config-bigpopakap) (2019-11-09)
+# [stylelint-config-bigpopakap-v1.2.0](https://github.com/bigpopakap/shared-node-tools/compare/v1.1.1-stylelint-config-bigpopakap...v1.2.0-stylelint-config-bigpopakap) (2019-11-09)
 
 
 ### Features
 
-* **bin-script:** don't specify file extensions to stylelint ([077db7d](https://github.com/bigpopakap/shared-ts-configs/commit/077db7dd59dcddea9ec3068aad26bacb98f47179)), closes [#60](https://github.com/bigpopakap/shared-ts-configs/issues/60)
-* **bin-scripts:** run in current dir, add more file exts ([4ea7a77](https://github.com/bigpopakap/shared-ts-configs/commit/4ea7a775d42305def5db43e91adaf7b73f640759)), closes [#60](https://github.com/bigpopakap/shared-ts-configs/issues/60)
+* **bin-script:** don't specify file extensions to stylelint ([077db7d](https://github.com/bigpopakap/shared-node-tools/commit/077db7dd59dcddea9ec3068aad26bacb98f47179)), closes [#60](https://github.com/bigpopakap/shared-node-tools/issues/60)
+* **bin-scripts:** run in current dir, add more file exts ([4ea7a77](https://github.com/bigpopakap/shared-node-tools/commit/4ea7a775d42305def5db43e91adaf7b73f640759)), closes [#60](https://github.com/bigpopakap/shared-node-tools/issues/60)
 
-# [stylelint-config-bigpopakap-v1.1.1](https://github.com/bigpopakap/shared-ts-configs/compare/v1.1.0-stylelint-config-bigpopakap...v1.1.1-stylelint-config-bigpopakap) (2019-11-04)
+# [stylelint-config-bigpopakap-v1.1.1](https://github.com/bigpopakap/shared-node-tools/compare/v1.1.0-stylelint-config-bigpopakap...v1.1.1-stylelint-config-bigpopakap) (2019-11-04)
 
 
 ### Bug Fixes
 
-* **ci:** fix autopublishing ([25b5002](https://github.com/bigpopakap/shared-ts-configs/commit/25b50021f284aaae64579632a02fe26815d6b49a)), closes [#56](https://github.com/bigpopakap/shared-ts-configs/issues/56)
-* **package.json:** update repo link to point to subdirectories ([5ee5a6a](https://github.com/bigpopakap/shared-ts-configs/commit/5ee5a6acad3345ab6d3f108a45e3f3ba2d844f49))
+* **ci:** fix autopublishing ([25b5002](https://github.com/bigpopakap/shared-node-tools/commit/25b50021f284aaae64579632a02fe26815d6b49a)), closes [#56](https://github.com/bigpopakap/shared-node-tools/issues/56)
+* **package.json:** update repo link to point to subdirectories ([5ee5a6a](https://github.com/bigpopakap/shared-node-tools/commit/5ee5a6acad3345ab6d3f108a45e3f3ba2d844f49))
 
-# [stylelint-config-bigpopakap-v1.1.0](https://github.com/bigpopakap/shared-ts-configs/compare/v1.0.1-stylelint-config-bigpopakap...v1.1.0-stylelint-config-bigpopakap) (2019-10-18)
+# [stylelint-config-bigpopakap-v1.1.0](https://github.com/bigpopakap/shared-node-tools/compare/v1.0.1-stylelint-config-bigpopakap...v1.1.0-stylelint-config-bigpopakap) (2019-10-18)
 
 
 ### Features
 
-* add binary script for stylelint-config-bigpopakap ([e0fccae](https://github.com/bigpopakap/shared-ts-configs/commit/e0fccae77194d2062673118d8b70c2f8bbe70a6d)), closes [#27](https://github.com/bigpopakap/shared-ts-configs/issues/27)
+* add binary script for stylelint-config-bigpopakap ([e0fccae](https://github.com/bigpopakap/shared-node-tools/commit/e0fccae77194d2062673118d8b70c2f8bbe70a6d)), closes [#27](https://github.com/bigpopakap/shared-node-tools/issues/27)
 
-# [stylelint-config-bigpopakap-v1.0.1](https://github.com/bigpopakap/shared-ts-configs/compare/v1.0.0-stylelint-config-bigpopakap...v1.0.1-stylelint-config-bigpopakap) (2019-10-16)
+# [stylelint-config-bigpopakap-v1.0.1](https://github.com/bigpopakap/shared-node-tools/compare/v1.0.0-stylelint-config-bigpopakap...v1.0.1-stylelint-config-bigpopakap) (2019-10-16)
 
 
 ### Bug Fixes
 
-* **package.json:** update description ([71d7b7e](https://github.com/bigpopakap/shared-ts-configs/commit/71d7b7e0acf5be7b49a64c53616d634dc157f056))
-* **readme:** update package description ([b6968c8](https://github.com/bigpopakap/shared-ts-configs/commit/b6968c8f603420720dea88037048677faf169073))
-* **readme:** update title ([3e27fe8](https://github.com/bigpopakap/shared-ts-configs/commit/3e27fe8b5309b70839954453a314ff0636fb2b9b))
+* **package.json:** update description ([71d7b7e](https://github.com/bigpopakap/shared-node-tools/commit/71d7b7e0acf5be7b49a64c53616d634dc157f056))
+* **readme:** update package description ([b6968c8](https://github.com/bigpopakap/shared-node-tools/commit/b6968c8f603420720dea88037048677faf169073))
+* **readme:** update title ([3e27fe8](https://github.com/bigpopakap/shared-node-tools/commit/3e27fe8b5309b70839954453a314ff0636fb2b9b))
 
 # stylelint-config-bigpopakap-v1.0.0 (2019-10-16)
 
 
 ### Bug Fixes
 
-* **autopublish:** try fixing autopublishing of multiple packages ([336a64c](https://github.com/bigpopakap/shared-ts-configs/commit/336a64ce5946173ad9b251c8c5d0423f263f1fba))
-* **autopublish:** try moving releaserc plugins into each package ([4c98eda](https://github.com/bigpopakap/shared-ts-configs/commit/4c98edadfa18f51780d80bab2da772b3ca2c11f5))
-* **autopublish:** trying to fix semantic-release ([a76b056](https://github.com/bigpopakap/shared-ts-configs/commit/a76b056eb31129208e6a193dc4bdcdb9b490eb93))
-* **autopublish:** undo recent changes to add plugins to packages ([2815e7a](https://github.com/bigpopakap/shared-ts-configs/commit/2815e7a82fc17dc4d07c33a709ab9d92d258d2f3))
-* **comments:** add better comments to stylelint rules configs ([237d887](https://github.com/bigpopakap/shared-ts-configs/commit/237d887675dde74506594807c2de804fcfd92a39))
+* **autopublish:** try fixing autopublishing of multiple packages ([336a64c](https://github.com/bigpopakap/shared-node-tools/commit/336a64ce5946173ad9b251c8c5d0423f263f1fba))
+* **autopublish:** try moving releaserc plugins into each package ([4c98eda](https://github.com/bigpopakap/shared-node-tools/commit/4c98edadfa18f51780d80bab2da772b3ca2c11f5))
+* **autopublish:** trying to fix semantic-release ([a76b056](https://github.com/bigpopakap/shared-node-tools/commit/a76b056eb31129208e6a193dc4bdcdb9b490eb93))
+* **autopublish:** undo recent changes to add plugins to packages ([2815e7a](https://github.com/bigpopakap/shared-node-tools/commit/2815e7a82fc17dc4d07c33a709ab9d92d258d2f3))
+* **comments:** add better comments to stylelint rules configs ([237d887](https://github.com/bigpopakap/shared-node-tools/commit/237d887675dde74506594807c2de804fcfd92a39))
 
 
 ### Features
 
-* **version:** publish 1.0.0 version ([f439ed8](https://github.com/bigpopakap/shared-ts-configs/commit/f439ed8d2b1cb53237f5918b0507e0920f518e6f))
+* **version:** publish 1.0.0 version ([f439ed8](https://github.com/bigpopakap/shared-node-tools/commit/f439ed8d2b1cb53237f5918b0507e0920f518e6f))
 
 # stylelint-config-bigpopakap-v1.0.0 (2019-10-16)
 
 
 ### Bug Fixes
 
-* **autopublish:** try fixing autopublishing of multiple packages ([336a64c](https://github.com/bigpopakap/shared-ts-configs/commit/336a64ce5946173ad9b251c8c5d0423f263f1fba))
-* **autopublish:** try moving releaserc plugins into each package ([4c98eda](https://github.com/bigpopakap/shared-ts-configs/commit/4c98edadfa18f51780d80bab2da772b3ca2c11f5))
-* **autopublish:** trying to fix semantic-release ([a76b056](https://github.com/bigpopakap/shared-ts-configs/commit/a76b056eb31129208e6a193dc4bdcdb9b490eb93))
-* **autopublish:** undo recent changes to add plugins to packages ([2815e7a](https://github.com/bigpopakap/shared-ts-configs/commit/2815e7a82fc17dc4d07c33a709ab9d92d258d2f3))
-* **comments:** add better comments to stylelint rules configs ([237d887](https://github.com/bigpopakap/shared-ts-configs/commit/237d887675dde74506594807c2de804fcfd92a39))
+* **autopublish:** try fixing autopublishing of multiple packages ([336a64c](https://github.com/bigpopakap/shared-node-tools/commit/336a64ce5946173ad9b251c8c5d0423f263f1fba))
+* **autopublish:** try moving releaserc plugins into each package ([4c98eda](https://github.com/bigpopakap/shared-node-tools/commit/4c98edadfa18f51780d80bab2da772b3ca2c11f5))
+* **autopublish:** trying to fix semantic-release ([a76b056](https://github.com/bigpopakap/shared-node-tools/commit/a76b056eb31129208e6a193dc4bdcdb9b490eb93))
+* **autopublish:** undo recent changes to add plugins to packages ([2815e7a](https://github.com/bigpopakap/shared-node-tools/commit/2815e7a82fc17dc4d07c33a709ab9d92d258d2f3))
+* **comments:** add better comments to stylelint rules configs ([237d887](https://github.com/bigpopakap/shared-node-tools/commit/237d887675dde74506594807c2de804fcfd92a39))
 
 
 ### Features
 
-* **version:** publish 1.0.0 version ([f439ed8](https://github.com/bigpopakap/shared-ts-configs/commit/f439ed8d2b1cb53237f5918b0507e0920f518e6f))
+* **version:** publish 1.0.0 version ([f439ed8](https://github.com/bigpopakap/shared-node-tools/commit/f439ed8d2b1cb53237f5918b0507e0920f518e6f))

--- a/stylelint-config-bigpopakap/package.json
+++ b/stylelint-config-bigpopakap/package.json
@@ -2,10 +2,10 @@
   "name": "stylelint-config-bigpopakap",
   "version": "1.2.1",
   "description": "Shared Stylelint configurations for bigpopakap's personal projects",
-  "homepage": "https://github.com/bigpopakap/shared-ts-configs",
+  "homepage": "https://github.com/bigpopakap/shared-node-tools",
   "repository": {
     "type": "git",
-    "url": "https://github.com/bigpopakap/shared-ts-configs"
+    "url": "https://github.com/bigpopakap/shared-node-tools"
   },
   "bin": {
     "stylelint-bigpopakap": "./bin/stylelint-bigpopakap.js"


### PR DESCRIPTION
rename all the link references after renaming the repo from bigpopakap/shared-ts-configs to
bigpopakap/shared-node-tools

fix #59