### PR TITLE
ci: run push build only on master

### DIFF
--- a/.github/workflows/node_ci.yml
+++ b/.github/workflows/node_ci.yml
@@ -1,8 +1,11 @@
 name: Node CI
 
 on:
-  push: {}
-  pull_request: {}
+  push:
+    branches:
+      - master
+  pull_request: {} # We must build on pull request so that commitlint can know what range of commits to analyze
+                   # and pushes to a branch can only analyze the most recent commit.
   schedule:
     - cron:  '0 */1 * * *' # Every hour, generated with https://crontab.guru/
 


### PR DESCRIPTION
semantic-release was failing to push tags to publish because pushing tags required this build to
pass. We will no longer require tag pushes to have a sucessfulbuild. Furthermore, to prevent double
builds on pull requests, this only run on pushes to the master branch (as well as any pull request).

fixes #86 after-the-fact