### PR TITLE
ci: add step to skip builds if the commit message requests it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,11 @@ jobs:
       CI: true
 
     steps:
+      - name: Skip build if requested
+        env:
+          COMMIT_FILTER: '[skip ci]' # This is what semantic-release uses in its version bump commit
+        uses: veggiemonk/skip-commit@master
+
       # Setup steps
       - name: Git checkout
         uses: actions/checkout@v1


### PR DESCRIPTION
This will help semantic-release because it can commit the package version update successfully.