### PR TITLE
ci: don't bother adding [skip ci] to release commit message

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -31,7 +31,7 @@ module.exports = {
     '@semantic-release/npm',
     {
       'path': '@semantic-release/git',
-      'message': 'chore(' + output.package + '): release ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}'
+      'message': 'chore(' + output.package + '): release ${nextRelease.version}\n\n${nextRelease.notes}'
     }
   ],
   publish: [


### PR DESCRIPTION
We're not enforcing any builds in branch protection rules in order to unblock semantic-release. Therefore, semantic-release
doesn't need to add the [skip ci] tag (it's unused).