### PR TITLE
ci: add Travis CI back

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -31,7 +31,7 @@ module.exports = {
     '@semantic-release/npm',
     {
       'path': '@semantic-release/git',
-      'message': 'chore(' + output.package + '): release ${nextRelease.version}\n\n${nextRelease.notes}'
+      'message': 'chore(' + output.package + '): release ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}'
     }
   ],
   publish: [

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: node_js
+
+jobs:
+  include:
+    - stage: "Automated Tests"
+      name: "List commit messages"
+      script: commitlint-travis
+    - name: "Lint code"
+      script: yarn lint
+    - stage: "Semantic Release"
+      name: "Release"
+      script: yarn release-all
+
+notifications:
+  email: false


### PR DESCRIPTION
Running CI on Github Actions had some problems. Mainly, it was incompatible with branch protection
rules, and semantic-release was failing. Travis CI worked, so this re-enables it.