### PR TITLE
fix(registry): move back to the npmjs registry

### DIFF
--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -7,8 +7,6 @@ Shared ESLint configurations for bigpopakap's personal projects.
 
 ## Installation
 
-First, authenticate [Github Packages][github-packages-setup] and add it to your local `npmrc`.
-
 ```bash
 yarn add -D @bigpopakap/eslint-config
 ```
@@ -56,5 +54,3 @@ You may want to add the following scripts to your `package.json`:
   }
 }
 ```
-
-[github-packages-setup]: https://help.github.com/en/github/managing-packages-with-github-packages/configuring-npm-for-use-with-github-packages

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -4,7 +4,6 @@
   "description": "Shared ESLint configurations for bigpopakap's personal projects",
   "homepage": "https://github.com/bigpopakap/shared-node-tools",
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
     "access": "public"
   },
   "repository": {

--- a/packages/renovate-config/README.md
+++ b/packages/renovate-config/README.md
@@ -11,8 +11,6 @@ Follow the [RenovateBot installation instructions][renovate-installation] to set
 
 ## Configuration
 
-First, authenticate [Github Packages][github-packages-setup] and add it to your local `npmrc`.
-
 ```bash
 yarn add -D @bigpopakap/renovate-config
 ```
@@ -27,6 +25,5 @@ Add the following `.renovaterc.json` to your project.
 ```
 And and add any other configurations you need specific to that repo.
 
-[github-packages-setup]: https://help.github.com/en/github/managing-packages-with-github-packages/configuring-npm-for-use-with-github-packages
 [renovate-installation]: https://docs.renovatebot.com/
 [renovate-config-options]: https://docs.renovatebot.com/configuration-options/

--- a/packages/renovate-config/package.json
+++ b/packages/renovate-config/package.json
@@ -4,7 +4,6 @@
   "description": "Shared RenovateBot configurations for bigpopakap's personal projects",
   "homepage": "https://github.com/bigpopakap/shared-node-tools",
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
     "access": "public"
   },
   "repository": {

--- a/packages/stylelint-config/README.md
+++ b/packages/stylelint-config/README.md
@@ -7,8 +7,6 @@ Shared Stylelint configurations for bigpopakap's personal projects.
 
 ## Installation
 
-First, authenticate [Github Packages][github-packages-setup] and add it to your local `npmrc`.
-
 ```bash
 yarn add -D @bigpopakap/stylelint-config
 ```
@@ -46,5 +44,3 @@ You may want to add the following scripts to your `package.json`:
   }
 }
 ```
-
-[github-packages-setup]: https://help.github.com/en/github/managing-packages-with-github-packages/configuring-npm-for-use-with-github-packages

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -4,7 +4,6 @@
   "description": "Shared Stylelint configurations for bigpopakap's personal projects",
   "homepage": "https://github.com/bigpopakap/shared-node-tools",
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
     "access": "public"
   },
   "repository": {


### PR DESCRIPTION
Github Packages did not support an "integrity" field on packages, so no other repos could install
these packages using yarn. That is a dealbreaker, so we're going back to npmjs