### PR TITLE
fix: bump versions by updating package descriptions

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigpopakap/eslint-config",
   "version": "1.0.18",
-  "description": "Shared ESLint configurations for bigpopakap's personal projects",
+  "description": "ESLint configuration for bigpopakap's personal projects",
   "homepage": "https://github.com/bigpopakap/shared-node-tools",
   "publishConfig": {
     "access": "public"

--- a/packages/renovate-config/package.json
+++ b/packages/renovate-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigpopakap/renovate-config",
   "version": "1.0.2",
-  "description": "Shared RenovateBot configurations for bigpopakap's personal projects",
+  "description": "RenovateBot configuration for bigpopakap's personal projects",
   "homepage": "https://github.com/bigpopakap/shared-node-tools",
   "publishConfig": {
     "access": "public"

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigpopakap/stylelint-config",
   "version": "1.0.3",
-  "description": "Shared Stylelint configurations for bigpopakap's personal projects",
+  "description": "Stylelint configuration for bigpopakap's personal projects",
   "homepage": "https://github.com/bigpopakap/shared-node-tools",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
this is mostly because the previous PR to switch to npmjs didn't work (because Travis was still
configured with my Github Packages token). Now that Travis has been updated, bump the versions
again. Hopefully this time it will publish to npmjs.