### PR TITLE
fix(package.json): update repository.url to include ".git" suffix

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/bigpopakap/shared-node-tools",
+    "url": "https://github.com/bigpopakap/shared-node-tools.git",
     "directory": "packages/eslint-config"
   },
   "bugs": "https://github.com/bigpopakap/shared-node-tools/issues",

--- a/packages/renovate-config/package.json
+++ b/packages/renovate-config/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/bigpopakap/shared-node-tools",
+    "url": "https://github.com/bigpopakap/shared-node-tools.git",
     "directory": "packages/renovate-config"
   },
   "bugs": "https://github.com/bigpopakap/shared-node-tools/issues",

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/bigpopakap/shared-node-tools",
+    "url": "https://github.com/bigpopakap/shared-node-tools.git",
     "directory": "packages/stylelint-config"
   },
   "bugs": "https://github.com/bigpopakap/shared-node-tools/issues",


### PR DESCRIPTION
RenovateBot is not able to pull the CHANGELOG.md file for these packages. I thought #193 would fix it, but it did not. Upon further inspection, I noticed that the "url" property in other repositories ends with ".git". Perhaps this will fix it.