### PR TITLE
feat(renovate-config): tweak bigpopakap renovate config

### DIFF
--- a/packages/renovate-config/package.json
+++ b/packages/renovate-config/package.json
@@ -32,22 +32,41 @@
       "extends": [
         "config:base"
       ],
+
       "assignees": [
         "bigpopakap"
       ],
-      "automerge": true,
+
+      "masterIssue": true,
+
       "semanticCommits": true,
       "commitBodyTable": true,
       "commitMessageTopic": "{{depName}}",
+
+      "separateMultipleMajor": true,
+      "stabilityDays": 3,
+
+      "automerge": true,
+
+      "peerDependencies": {
+        "enabled": true
+      },
+
       "packageRules": [
         {
+          "updateTypes": ["major"],
+          "automerge": false
+        },
+        {
           "packagePatterns": [
+            "^@[\\w-]+?\\/eslint",
             "^eslint"
           ],
           "groupName": "eslint packages"
         },
         {
           "packagePatterns": [
+            "^@[\\w-]+?\\/styleint",
             "^styleint"
           ],
           "groupName": "styelint packages"
@@ -59,10 +78,7 @@
           ],
           "groupName": "semantic-release packages"
         }
-      ],
-      "peerDependencies": {
-        "enabled": true
-      }
+      ]
     }
   }
 }


### PR DESCRIPTION
reorder properties and add whitespace for grouping
add masterIssue=true
add separateMultipleMajor=true
add stabilityDays=3
disable automerge for major versions
add matcher for @scope/eslint packages
add matcher for @scope/stylelint packages