### PR TITLE
feat(renovate-config/bigpopakap): update automerge behavior

### DIFF
--- a/packages/renovate-config/package.json
+++ b/packages/renovate-config/package.json
@@ -32,6 +32,9 @@
       "extends": [
         "config:base"
       ],
+      "reviewers": [
+        "bigpopakap"
+      ],
       "assignees": [
         "bigpopakap"
       ],
@@ -40,7 +43,6 @@
       "commitBodyTable": true,
       "commitMessageTopic": "{{depName}}",
       "separateMultipleMajor": true,
-      "stabilityDays": 3,
       "automerge": true,
       "peerDependencies": {
         "enabled": true
@@ -50,7 +52,8 @@
           "updateTypes": [
             "major"
           ],
-          "automerge": false
+          "automerge": true,
+          "stabilityDays": 3
         },
         {
           "packagePatterns": [


### PR DESCRIPTION
set automerge=true for all dependencies again, and only set stabilityDays=3 for major version bumps.
add reviewers so that major version bumps have a chance to be seen before automerging